### PR TITLE
One to many approach for event subscriptions

### DIFF
--- a/src/test/mutation-transfer/addEventListener.test.ts
+++ b/src/test/mutation-transfer/addEventListener.test.ts
@@ -41,13 +41,8 @@ test.serial.cb('Node.addEventListener transfers an event subscription', (t) => {
       [
         TransferrableMutationType.EVENT_SUBSCRIPTION,
         div[TransferrableKeys.index],
-        0,
         1,
         strings.indexOf('click'),
-        0, // This is the first event registered.
-        NumericBoolean.FALSE,
-        NumericBoolean.FALSE,
-        NumericBoolean.FALSE,
         NumericBoolean.FALSE,
       ],
       'mutation is as expected',
@@ -61,93 +56,6 @@ test.serial.cb('Node.addEventListener transfers an event subscription', (t) => {
   });
 });
 
-test.serial.cb('Node.addEventListener(..., {capture: true}) transfers an event subscription', (t) => {
-  const { div, eventHandler, emitter } = t.context;
-
-  function transmitted(strings: Array<string>, message: MutationFromWorker, buffers: Array<ArrayBuffer>) {
-    t.deepEqual(
-      Array.from(new Uint16Array(message[TransferrableKeys.mutations])),
-      [
-        TransferrableMutationType.EVENT_SUBSCRIPTION,
-        div[TransferrableKeys.index],
-        0,
-        1,
-        strings.indexOf('click'),
-        0, // This is the first event registered.
-        NumericBoolean.TRUE,
-        NumericBoolean.FALSE,
-        NumericBoolean.FALSE,
-        NumericBoolean.FALSE,
-      ],
-      'mutation is as expected',
-    );
-    t.end();
-  }
-
-  Promise.resolve().then(() => {
-    emitter.once(transmitted);
-    div.addEventListener('click', eventHandler, { capture: true });
-  });
-});
-
-test.serial.cb('Node.addEventListener(..., {once: true}) transfers an event subscription', (t) => {
-  const { div, eventHandler, emitter } = t.context;
-
-  function transmitted(strings: Array<string>, message: MutationFromWorker, buffers: Array<ArrayBuffer>) {
-    t.deepEqual(
-      Array.from(new Uint16Array(message[TransferrableKeys.mutations])),
-      [
-        TransferrableMutationType.EVENT_SUBSCRIPTION,
-        div[TransferrableKeys.index],
-        0,
-        1,
-        strings.indexOf('click'),
-        0, // This is the first event registered.
-        NumericBoolean.FALSE,
-        NumericBoolean.TRUE,
-        NumericBoolean.FALSE,
-        NumericBoolean.FALSE,
-      ],
-      'mutation is as expected',
-    );
-    t.end();
-  }
-
-  Promise.resolve().then(() => {
-    emitter.once(transmitted);
-    div.addEventListener('click', eventHandler, { once: true });
-  });
-});
-
-test.serial.cb('Node.addEventListener(..., {passive: true}) transfers an event subscription', (t) => {
-  const { div, eventHandler, emitter } = t.context;
-
-  function transmitted(strings: Array<string>, message: MutationFromWorker, buffers: Array<ArrayBuffer>) {
-    t.deepEqual(
-      Array.from(new Uint16Array(message[TransferrableKeys.mutations])),
-      [
-        TransferrableMutationType.EVENT_SUBSCRIPTION,
-        div[TransferrableKeys.index],
-        0,
-        1,
-        strings.indexOf('click'),
-        0, // This is the first event registered.
-        NumericBoolean.FALSE,
-        NumericBoolean.FALSE,
-        NumericBoolean.TRUE,
-        NumericBoolean.FALSE,
-      ],
-      'mutation is as expected',
-    );
-    t.end();
-  }
-
-  Promise.resolve().then(() => {
-    emitter.once(transmitted);
-    div.addEventListener('click', eventHandler, { passive: true });
-  });
-});
-
 test.serial.cb('Node.addEventListener(..., {workerDOMPreventDefault: true}) transfers an event subscription', (t) => {
   const { div, eventHandler, emitter } = t.context;
 
@@ -157,13 +65,8 @@ test.serial.cb('Node.addEventListener(..., {workerDOMPreventDefault: true}) tran
       [
         TransferrableMutationType.EVENT_SUBSCRIPTION,
         div[TransferrableKeys.index],
-        0,
         1,
         strings.indexOf('click'),
-        0, // This is the first event registered.
-        NumericBoolean.FALSE,
-        NumericBoolean.FALSE,
-        NumericBoolean.FALSE,
         NumericBoolean.TRUE,
       ],
       'mutation is as expected',
@@ -177,4 +80,29 @@ test.serial.cb('Node.addEventListener(..., {workerDOMPreventDefault: true}) tran
       workerDOMPreventDefault: true,
     });
   });
+});
+
+test.serial.cb('Node.addEventListener transfers an event subscription only once', (t) => {
+    const { div, eventHandler, emitter } = t.context;
+
+    function transmitted(strings: Array<string>, message: MutationFromWorker, buffers: Array<ArrayBuffer>) {
+        t.deepEqual(
+            Array.from(new Uint16Array(message[TransferrableKeys.mutations])),
+            [
+                TransferrableMutationType.EVENT_SUBSCRIPTION,
+                div[TransferrableKeys.index],
+                1,
+                strings.indexOf('click'),
+                NumericBoolean.FALSE,
+            ],
+            'mutation is as expected',
+        );
+        t.end();
+    }
+
+    Promise.resolve().then(() => {
+        emitter.once(transmitted);
+        div.addEventListener('click', (e) => console.log('0th listener'));
+        div.addEventListener('click', eventHandler);
+    });
 });

--- a/src/test/mutation-transfer/removeEventListener.test.ts
+++ b/src/test/mutation-transfer/removeEventListener.test.ts
@@ -37,7 +37,7 @@ test.serial.cb('Node.removeEventListener transfers an event subscription', (t) =
   function transmitted(strings: Array<string>, message: MutationFromWorker, buffers: Array<ArrayBuffer>) {
     t.deepEqual(
       Array.from(new Uint16Array(message[TransferrableKeys.mutations])),
-      [TransferrableMutationType.EVENT_SUBSCRIPTION, div[TransferrableKeys.index], 1, 0, strings.indexOf('click'), 0],
+      [TransferrableMutationType.EVENT_SUBSCRIPTION, div[TransferrableKeys.index], 0, strings.indexOf('click'), 0],
       'mutation is as expected',
     );
     t.end();
@@ -50,16 +50,11 @@ test.serial.cb('Node.removeEventListener transfers an event subscription', (t) =
   });
 });
 
-test.serial.cb('Node.removeEventListener transfers the correct subscription when multiple exist', (t) => {
+test.serial.cb('Node.removeEventListener not transfers the subscription when multiple exist', (t) => {
   const { div, eventHandler, emitter } = t.context;
 
   function transmitted(strings: Array<string>, message: MutationFromWorker, buffers: Array<ArrayBuffer>) {
-    t.deepEqual(
-      Array.from(new Uint16Array(message[TransferrableKeys.mutations])),
-      [TransferrableMutationType.EVENT_SUBSCRIPTION, div[TransferrableKeys.index], 1, 0, strings.indexOf('click'), 1],
-      'mutation is as expected',
-    );
-    t.end();
+    throw 'Should not be called';
   }
 
   div.addEventListener('click', (e) => console.log('0th listener'));
@@ -67,5 +62,6 @@ test.serial.cb('Node.removeEventListener transfers the correct subscription when
   Promise.resolve().then(() => {
     emitter.once(transmitted);
     div.removeEventListener('click', eventHandler);
+    t.end();
   });
 });

--- a/src/transfer/TransferrableEvent.ts
+++ b/src/transfer/TransferrableEvent.ts
@@ -43,37 +43,6 @@ export interface TransferrableEvent {
 }
 
 /**
- * Add Event Registration Transfer
- *
- * [
- *   type,
- *   index,
- *   capture,
- *   once,
- *   passive,
- *   workerDOMPreventDefault
- * ]
- */
-export const enum AddEventRegistrationIndex {
-  Type = 0,
-  Index = 1,
-  Capture = 2,
-  Once = 3,
-  Passive = 4,
-  WorkerDOMPreventDefault = 5,
-}
-export const ADD_EVENT_SUBSCRIPTION_LENGTH = 6;
-
-/**
- * Remove Event Registration Transfer
- */
-export const enum RemoveEventRegistrationIndex {
-  Type = 0,
-  Index = 1,
-}
-export const REMOVE_EVENT_SUBSCRIPTION_LENGTH = 2;
-
-/**
  * Event Subscription Transfer
  *
  * [
@@ -87,8 +56,8 @@ export const REMOVE_EVENT_SUBSCRIPTION_LENGTH = 2;
  */
 export const enum EventSubscriptionMutationIndex {
   Target = 1,
-  RemoveEventListenerCount = 2,
-  AddEventListenerCount = 3,
-  Events = 4,
-  End = 4,
+  IsAddEvent = 2,
+  EventType = 3,
+  PreventDefault = 4,
+  End = 5,
 }


### PR DESCRIPTION
Only one subscription for the specific event should be transferred to the main thread. Multiple subscriptions should be handled on worker tread. 